### PR TITLE
docs: add JSDoc comment to clickButton action creator

### DIFF
--- a/src/toolbar/actions.js
+++ b/src/toolbar/actions.js
@@ -1,7 +1,7 @@
 import * as t from './actionTypes';
 
 /**
- * Creates an action to handle a toolbar button click.
+ * Creates a Redux action to handle a toolbar button click.
  * @param {string} id - The id of the button that was clicked.
  * @returns {{type: string, id: string}} A CLICK_BUTTON action object.
  */

--- a/src/toolbar/actions.js
+++ b/src/toolbar/actions.js
@@ -3,6 +3,7 @@ import * as t from './actionTypes';
 /**
  * Creates an action to handle a toolbar button click.
  * @param {string} id - The id of the button that was clicked.
+ * @returns {{type: string, id: string}} A CLICK_BUTTON action object.
  */
 export const clickButton = (id) => ({
     type: t.CLICK_BUTTON,

--- a/src/toolbar/actions.js
+++ b/src/toolbar/actions.js
@@ -1,5 +1,9 @@
 import * as t from './actionTypes';
 
+/**
+ * Creates an action to handle a toolbar button click.
+ * @param {string} id - The id of the button that was clicked.
+ */
 export const clickButton = (id) => ({
     type: t.CLICK_BUTTON,
     id


### PR DESCRIPTION
## Summary
- Adds a JSDoc comment to `clickButton` in `src/toolbar/actions.js` documenting its parameter

## Test plan
- [ ] No logic changes — visual review only

🤖 Generated with [Claude Code](https://claude.com/claude-code)