### PR TITLE
fix: add id-token write permission to pr-classify workflow

### DIFF
--- a/.github/workflows/pr-classify.yml
+++ b/.github/workflows/pr-classify.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   classify:


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the PR Classification workflow
- `claude-code-action@beta` requires this to fetch a GitHub OIDC token; without it the classifier step fails silently and the workflow posts a "could not determine PR type" warning

## Test plan
- [ ] Open a PR and verify the classification comment appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)