### PR TITLE
fix: pass github_token explicitly to claude-code-action

### DIFF
--- a/.github/workflows/pr-classify.yml
+++ b/.github/workflows/pr-classify.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           model: claude-haiku-4-5-20251001
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           direct_prompt: |
             You are classifying a pull request for jitsi-meet, an open-source WebRTC


### PR DESCRIPTION
## Summary
- Adds `github_token: ${{ secrets.GITHUB_TOKEN }}` to the Classify PR step
- Without it, `claude-code-action@beta` attempts to exchange the OIDC token for a Claude Code GitHub App token, which fails with 401 when the app is not installed

## Test plan
- [ ] Merge and verify the next PR triggers a successful classification comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)