### PR TITLE
fix: use heredoc format for multi-line GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/pr-classify.yml
+++ b/.github/workflows/pr-classify.yml
@@ -77,8 +77,10 @@ jobs:
               messages: [{role: "user", content: $prompt}]
             }')")
 
-          OUTPUT=$(echo "$RESPONSE" | jq -r '.content[0].text')
-          echo "output=$OUTPUT" >> $GITHUB_OUTPUT
+          OUTPUT=$(echo "$RESPONSE" | jq -r '.content[0].text' | tr -d '\n')
+          echo "output<<EOF_DELIMITER" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF_DELIMITER" >> $GITHUB_OUTPUT
 
       - name: Apply labels and post comment
         if: always()


### PR DESCRIPTION
## Summary
- Fixes `Invalid format '{'` error when writing the classifier output to `GITHUB_OUTPUT`
- Multi-line values must use the `key<<delimiter` heredoc syntax; plain `echo "key=value"` fails when the value contains newlines or `{`
- Also strips newlines from the response to simplify the output

## Test plan
- [ ] Merge and verify PR #11 (or trigger a new one) gets a label applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)