### PR TITLE
feature: show unread message badge on chat toolbar button

### DIFF
--- a/src/toolbar/components/ToolbarButtonView.js
+++ b/src/toolbar/components/ToolbarButtonView.js
@@ -6,6 +6,8 @@ import React from 'react';
 
 class ToolbarButtonView extends React.Component {
     render () {
+        const { unreadMessages } = this.props;
+
         return <a className={this.props.buttonClassName}
                   id={this.props.id}
                   data-container="body"
@@ -14,7 +16,11 @@ class ToolbarButtonView extends React.Component {
                   shortcut={this.props.buttonShortcut}
                   data-i18n={this.props.i18nTextKey}
                   content={this.props.tooltipText}
-                  onClick={this.props.onClick}></a>;
+                  onClick={this.props.onClick}>
+            { unreadMessages > 0 &&
+                <span className="badge">{unreadMessages}</span>
+            }
+        </a>;
     }
 }
 

--- a/src/toolbar/components/ToolbarContainerView.js
+++ b/src/toolbar/components/ToolbarContainerView.js
@@ -27,6 +27,7 @@ class ToolbarContainerView extends React.Component {
                     i18nTextKey={toolbarButton.i18nTextKey}
                     tooltipText={toolbarButton.tooltipText}
                     toggled={toolbarButton.toggled}
+                    unreadMessages={toolbarButton.unreadMessages}
                     //{...toolbarButton}
                     onClick={() => this.props.onToolbarClick(toolbarButton.id)}
                     />


### PR DESCRIPTION
## Summary
- Renders a `<span class="badge">` with the unread count on the chat button when `unreadMessages > 0`
- Passes `unreadMessages` from `ToolbarContainerView` down to `ToolbarButtonView`
- The count is already tracked in Redux state — this just wires up the display

## Test plan
- [ ] Set `unreadMessages` to a non-zero value in the initial state and verify the badge appears on the chat button

🤖 Generated with [Claude Code](https://claude.com/claude-code)